### PR TITLE
B also close handle, if WlanQueryInterface fails

### DIFF
--- a/win32wifi/Win32Wifi.py
+++ b/win32wifi/Win32Wifi.py
@@ -411,7 +411,11 @@ def queryInterface(wireless_interface, opcode_item):
         if val == opcode_item_ext:
             opcode = WLAN_INTF_OPCODE(key)
             break
-    result = WlanQueryInterface(handle, wireless_interface.guid, opcode)
+    try:
+        result = WlanQueryInterface(handle, wireless_interface.guid, opcode)
+    except Exception as e:
+        WlanCloseHandle(handle)
+        raise e
     WlanCloseHandle(handle)
     r = result.contents
     if opcode_item == "interface_state":


### PR DESCRIPTION
This pull request fixes an interesting issue.
If a device has no Wi-Fi connected, it is still possible to do:
`handle = WlanOpenHandle()`
But when calling `WlanQueryInterface`, there is an exception.
In the original code, the handle is not closed, which doesn't seem to harm for exactly 20 times.
But at the 21st time, now already opening the handle fails.
This can be easily fixed by also closing the handle, if `WlanQueryInterface` fails.